### PR TITLE
nico/initialize cmd

### DIFF
--- a/programs/polymer-prover/src/lib.rs
+++ b/programs/polymer-prover/src/lib.rs
@@ -139,6 +139,8 @@ pub mod polymer_prover {
 
     use instructions::validate_event::ValidateEventResult;
 
+    use crate::instructions::parse_event::EthAddress;
+
     use super::*;
 
     #[event]
@@ -165,6 +167,12 @@ pub mod polymer_prover {
         internal.signer_addr = signer_addr;
         internal.peptide_chain_id = peptide_chain_id;
 
+        msg!("client_type: {}", internal.client_type);
+        msg!("peptide_chain_id: {}", internal.peptide_chain_id);
+        msg!(
+            "signer_addr: {}",
+            EthAddress::from_bytes(&internal.signer_addr).to_hex()
+        );
         Ok(())
     }
 

--- a/tools/proverctl/src/main.rs
+++ b/tools/proverctl/src/main.rs
@@ -41,6 +41,16 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    Initialize {
+        #[arg(long)]
+        client_type: String,
+
+        #[arg(long)]
+        signer_addr: String,
+
+        #[arg(long)]
+        peptide_chain_id: u64,
+    },
     ClearCache,
     ResizeCache,
 }
@@ -61,6 +71,11 @@ fn main() -> Result<()> {
 
     let client = Client::new(cli.program_id, signer, &cli.cluster)?;
     match &cli.command {
+        Commands::Initialize {
+            client_type,
+            signer_addr,
+            peptide_chain_id,
+        } => client.send_initialize(client_type, signer_addr, *peptide_chain_id)?,
         Commands::ResizeCache => client.send_resize_cache()?,
         Commands::ClearCache => client.send_clear_cache()?,
     }


### PR DESCRIPTION
- **parse_event: fix eth address parsing**
- **proverctl: add initialize command**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Initialize" command to the CLI, allowing users to initialize with custom parameters.
- **Bug Fixes**
  - Improved handling of Ethereum address hex strings, ensuring correct zero-padding and alignment for shorter inputs.
- **Tests**
  - Introduced new tests to verify Ethereum address parsing and zero-padding behavior.
- **Chores**
  - Enhanced debug logging for internal state during initialization.
  - Updated test setup to use the new CLI initialization command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->