### PR TITLE
Fix typo in documentation comment in lib.rs

### DIFF
--- a/programs/cpi-client/src/lib.rs
+++ b/programs/cpi-client/src/lib.rs
@@ -44,7 +44,7 @@ pub struct CallValidateEvent<'info> {
 
 /// this simple program is meant to be used only for testing the CPI capabilities of our
 /// polymer_prover program
-/// It exposes two instrctions: call_load_proof and call_validate_event, that simply call into
+/// It exposes two instructions: call_load_proof and call_validate_event, that simply call into
 /// their cousins on the prover
 /// For simplicity, the proof is loaded into the binary itself and not provided by the caller.
 #[program]


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the documentation comment of the file programs/cpi-client/src/lib.rs. The word "instrctions" has been changed to "instructions" for improved clarity and accuracy. No functional code changes are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the documentation to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->