### PR TITLE
organize accounts and comments

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -96,7 +96,7 @@ describe("localnet", () => {
       .rpc(confirmOptions);
 
     // at this point the first chunk should be stored in the cache pda
-    const cachePda = findProgramAddress([newSigner.publicKey.toBuffer()], program.programId);
+    const cachePda = findProgramAddress([Buffer.from("cache"), newSigner.publicKey.toBuffer()], program.programId);
     const cache0 = await program.account.proofCacheAccount.fetch(cachePda, "confirmed")
     assert.deepEqual(proof.subarray(0, 800), cache0.cache)
 
@@ -153,8 +153,8 @@ describe("localnet", () => {
     ])
 
     // at this point the first chunks should be stored in their respective pda accounts
-    const cachePda0 = findProgramAddress([user0.publicKey.toBuffer()], program.programId);
-    const cachePda1 = findProgramAddress([user1.publicKey.toBuffer()], program.programId);
+    const cachePda0 = findProgramAddress([Buffer.from("cache"), user0.publicKey.toBuffer()], program.programId);
+    const cachePda1 = findProgramAddress([Buffer.from("cache"), user1.publicKey.toBuffer()], program.programId);
 
     {
       const caches = await Promise.all([
@@ -327,7 +327,7 @@ describe("localnet", () => {
 
   it("clears cache", async () => {
     const newSigner = await generateAndFundNewSigner()
-    const cacheAccount = findProgramAddress([newSigner.publicKey.toBuffer()], program.programId);
+    const cacheAccount = findProgramAddress([Buffer.from("cache"), newSigner.publicKey.toBuffer()], program.programId);
 
     // the cache account of the new signer will only be created when loadProof is called
     try {
@@ -363,7 +363,7 @@ describe("localnet", () => {
   it("runs proverctl", async () => {
     const newSigner = await generateAndFundNewSigner()
 
-    const cacheAccount = findProgramAddress([newSigner.publicKey.toBuffer()], program.programId);
+    const cacheAccount = findProgramAddress([Buffer.from("cache"), newSigner.publicKey.toBuffer()], program.programId);
 
     await program.methods
       .loadProof(proof.subarray(0, 600))
@@ -385,7 +385,7 @@ describe("localnet", () => {
 
   it("support cpi calls", async () => {
     const newSigner = await generateAndFundNewSigner()
-    const cacheAccount = findProgramAddress([newSigner.publicKey.toBuffer()], program.programId)
+    const cacheAccount = findProgramAddress([Buffer.from("cache"), newSigner.publicKey.toBuffer()], program.programId);
 
     await cpiclient.methods
       .callLoadProof()

--- a/tools/proverctl/src/prover_client.rs
+++ b/tools/proverctl/src/prover_client.rs
@@ -47,8 +47,8 @@ impl Client {
             program_id: self.program_id,
             data: Initialize::data(&data),
             accounts: vec![
-                AccountMeta::new(internal_account, false),
                 AccountMeta::new(self.payer.pubkey(), true),
+                AccountMeta::new(internal_account, false),
                 AccountMeta::new_readonly(solana_sdk::system_program::id(), false),
             ],
         };
@@ -64,8 +64,8 @@ impl Client {
             program_id: self.program_id,
             data: ClearProofCache.data(),
             accounts: vec![
-                AccountMeta::new(cache_account, false),
                 AccountMeta::new(self.payer.pubkey(), true),
+                AccountMeta::new(cache_account, false),
                 AccountMeta::new_readonly(solana_sdk::system_program::id(), false),
             ],
         };
@@ -76,7 +76,7 @@ impl Client {
     }
 
     fn find_cache_account(&self) -> Pubkey {
-        let (account, _) = Pubkey::find_program_address(&[self.payer.pubkey().as_ref()], &self.program_id);
+        let (account, _) = Pubkey::find_program_address(&[b"cache", self.payer.pubkey().as_ref()], &self.program_id);
         info!("CACHE: {}", account);
         account
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized account ordering across all instructions, placing the authority account first and updating related method signatures, validation messages, and display order.
  - Unified PDA derivation for cache accounts by introducing a fixed "cache" prefix to all relevant address calculations.
  - Clarified and consolidated authority fields in account context definitions, ensuring consistent role assignment and documentation.

- **Tests**
  - Updated test cases to use the new PDA derivation scheme with the "cache" prefix for cache accounts.

- **Chores**
  - Adjusted client and CLI account ordering and PDA derivation logic to align with program changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->