### PR TITLE
bump github actions to latest majors

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -39,7 +39,7 @@ runs:
         git config --global url."https://x-access-token:${{ inputs.token }}@github.com/".insteadOf "https://github.com/"
 
     - name: Cache Yarn
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/yarn
@@ -60,7 +60,7 @@ runs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go/go.mod
         cache-dependency-path: go/go.sum

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ permissions:
 
 jobs:
   build-test:
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-24.04-16core
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,11 +28,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-24.04-16core
     environment: ${{ inputs.polyenv }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,10 @@ permissions:
 
 jobs:
   build-test-release:
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-24.04-16core
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
         run: ./scripts/package-release.sh
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release/**
           generate_release_notes: true
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go/go.mod
           cache-dependency-path: go/go.sum


### PR DESCRIPTION
checkout v4->v6, setup-go v5->v6, cache v4->v5, action-gh-release v2->v3.
all four bumps move the action runtime to node 24. also bump runners to
ubuntu-24.04-16core to match.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
